### PR TITLE
Fix error for new_item in non-English config

### DIFF
--- a/dist/custom-sidebar.js
+++ b/dist/custom-sidebar.js
@@ -157,8 +157,8 @@ function createItem(elements, item) {
 function getConfigurationElement(elements) {
   for (var i = 0; i < elements.children.length; i++) {
     if (elements.children[i].tagName == "A") {
-      var current = elements.children[i].children[0].getElementsByTagName("span")[0].innerHTML;
-      if (current == "<!---->Configuration<!---->") {
+      var current = elements.children[i].getAttribute("data-panel");
+      if (current == "config") {
         return elements.children[i];
       }
     }


### PR DESCRIPTION
The way the function `getConfigurationElement` searches for the configuration-element is broken in any non-English HAss (as the element is not called "Configuration").
The easiest way to fix this is by searching for the attribute data-panel rather than string.