### PR TITLE
Fix error with null element

### DIFF
--- a/dist/custom-sidebar.js
+++ b/dist/custom-sidebar.js
@@ -157,7 +157,9 @@ function getSidebar() {
 }
 
 function createItem(elements, item) {
-  var cln = getConfigurationElement(elements).cloneNode(true);
+  var cln = null;
+  if (getConfigurationElement(elements))
+     cln = getConfigurationElement(elements).cloneNode(true);
   if (cln) {
     cln.querySelector("paper-icon-item").querySelector("ha-icon").setAttribute("icon", item.icon);
     cln.querySelector("paper-icon-item").querySelector("span").innerHTML = item.item;


### PR DESCRIPTION
Hello,

I've been getting an error, when using this on a iPhone with user permissions, rather than admin permissions.
Not 100% sure what is going on, but think it's because some of the sidebars are hidden for users.

Anyway, this pull fixes it!

Cheers.
