### PR TITLE
Added new option to allow links to open in new browser window

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ order:
 | hide | boolean | **Optional** | Hide item in sidebar.
 | exact | boolean | **Optional** | Specify whether the item string match will be exact match instead of substring.
 | href | string | **Optional** | Define the href for the sidebar link.
+| open_new | boolean | **Optional** | Specify whether the link should open in a new browser window.
 | icon | string | **Optional** | Set the icon of the sidebar item.
 | new_item | boolean | **Optional** | Set to true to create a new link in the sidebar. Using this option now makes `item`, `href`, and `icon` required.
 
@@ -142,6 +143,7 @@ order:
   - new_item: true
     item: Server Controls
     href: /config/server_control
+    open_new: true
     icon: "mdi:server"
     bottom: true
 exceptions:

--- a/dist/custom-sidebar.js
+++ b/dist/custom-sidebar.js
@@ -197,7 +197,7 @@ function moveItem(elements, config_entry) {
           elements.children[i].href = config_entry.href;
         }
         
-        if (config_entry.open_nef) {
+        if (config_entry.open_new) {
           elements.children[i].setAttribute("target", "_blank");
         }
 

--- a/dist/custom-sidebar.js
+++ b/dist/custom-sidebar.js
@@ -162,6 +162,9 @@ function createItem(elements, item) {
     cln.querySelector("paper-icon-item").querySelector("ha-icon").setAttribute("icon", item.icon);
     cln.querySelector("paper-icon-item").querySelector("span").innerHTML = item.item;
     cln.href = item.href;
+    if (item.open_new == true) {
+      cln.setAttribute("target", "_blank");
+    }
     cln.setAttribute("data-panel", item.item);
     elements.insertBefore(cln, elements.children[0]);
   }

--- a/dist/custom-sidebar.js
+++ b/dist/custom-sidebar.js
@@ -196,6 +196,10 @@ function moveItem(elements, config_entry) {
         if (config_entry.href) {
           elements.children[i].href = config_entry.href;
         }
+        
+        if (config_entry.open_nef) {
+          elements.children[i].setAttribute("target", "_blank");
+        }
 
         if (config_entry.name) {
           elements.children[i].children[0].getElementsByTagName("span")[0].innerHTML = elements.children[i].children[0].getElementsByTagName("span")[0].innerHTML.replace(current, config_entry.name);


### PR DESCRIPTION
Added a new boolean  config option "open_new" which sets target="_blank" in the anchor tag for the sidebar item to make it open in a new window. Works for both existing and new items (new_item).

The documentation has also been updated to reflect this option.