### PR TITLE
Use textContent instead of innerHTML for title matching

### DIFF
--- a/dist/custom-sidebar.js
+++ b/dist/custom-sidebar.js
@@ -181,7 +181,7 @@ function getConfigurationElement(elements) {
 function moveItem(elements, config_entry) {
   for (var i = 0; i < elements.children.length; i++) {
     if (elements.children[i].tagName == "A") {
-      var current = elements.children[i].children[0].getElementsByTagName("span")[0].innerHTML.replace('<!---->', '').replace('<!---->', '');
+      var current = elements.children[i].children[0].getElementsByTagName("span")[0].textContent;
       var match = false;
       if (config_entry.exact) {
         match = current == config_entry.item;


### PR DESCRIPTION
This is in regards to the issue I posted a little while ago, https://github.com/Villhellm/custom-sidebar/issues/45.

I tested the change and it does seem to fix the issue I was having with exact matching. Now, it matches all of my titles properly even when they all use exact matching, whereas before it only matched a few of them with exact matching due to HTML comments.

innerText could also possibly work, but I think textContent is a better choice because it includes only visible text and also merges text from child elements.